### PR TITLE
Fix typo in a comment in the config file

### DIFF
--- a/paper/src/main/resources/config.yml
+++ b/paper/src/main/resources/config.yml
@@ -125,7 +125,7 @@ Anti_Spam:
       - "/spawn"
 
 #=================================================================================================#
-# Prevent players from swearing in chat, comamnds, and signs.
+# Prevent players from swearing in chat, commands, and signs.
 #=================================================================================================#
 Anti_Swear:
   Chat:


### PR DESCRIPTION
The word "commands" is spelled wrong.