### PR TITLE
Update workflows

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -1,0 +1,23 @@
+name: Dev Build
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+      - name: Build
+        run: ./gradlew build --stacktrace
+      - name: Publish to Modrinth
+        run: ./gradlew modrinth --stacktrace
+        env:
+          MODRINTH_TOKEN: ${{ secrets.MODRINTH_TOKEN }}
+          COMMIT_MESSAGE: ${{ join(github.event.commits.*.message, '<br>') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release
+name: Release Build
 on:
   release:
     types: [ published ]
@@ -11,14 +11,18 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
         with:
-          distribution: 'temurin'
-          java-version: '21'
+          distribution: temurin
+          java-version: 21
       - name: Read Version Catalog
         uses: SebRollen/toml-action@v1.2.0
         id: chatmanager_version
         with:
           file: "gradle/libs.versions.toml"
           field: "versions.chatmanager"
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+      - name: Make gradlew executable
+        run: chmod +x ./gradlew
       - name: Build
         run: ./gradlew build --stacktrace
       - name: Publish to Modrinth

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,6 @@ name: Release
 on:
   release:
     types: [ published ]
-    branches:
-      - main
 
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,29 @@
+name: Release
+on:
+  release:
+    types: [ published ]
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+      - name: Read Version Catalog
+        uses: SebRollen/toml-action@v1.2.0
+        id: chatmanager_version
+        with:
+          file: "gradle/libs.versions.toml"
+          field: "versions.chatmanager"
+      - name: Build
+        run: ./gradlew build --stacktrace
+      - name: Publish to Modrinth
+        run: ./gradlew modrinth --stacktrace
+        env:
+          MODRINTH_TOKEN: ${{ secrets.MODRINTH_TOKEN }}

--- a/.github/workflows/snapshots.yml
+++ b/.github/workflows/snapshots.yml
@@ -16,6 +16,8 @@ jobs:
           java-version: 21
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
+      - name: Make gradlew executable
+        run: chmod +x ./gradlew
       - name: Build
         run: ./gradlew build --stacktrace
       - name: Publish to Modrinth

--- a/.github/workflows/snapshots.yml
+++ b/.github/workflows/snapshots.yml
@@ -1,4 +1,6 @@
 name: Dev Build
+env:
+  IS_SNAPSHOT: true
 on:
   push:
     branches:
@@ -25,4 +27,3 @@ jobs:
         env:
           MODRINTH_TOKEN: ${{ secrets.MODRINTH_TOKEN }}
           COMMIT_MESSAGE: ${{ join(github.event.commits.*.message, '<br>') }}
-          IS_SNAPSHOT: true

--- a/.github/workflows/snapshots.yml
+++ b/.github/workflows/snapshots.yml
@@ -1,4 +1,4 @@
-name: Dev Build
+name: Snapshot Build
 env:
   IS_SNAPSHOT: true
 on:

--- a/.github/workflows/snapshots.yml
+++ b/.github/workflows/snapshots.yml
@@ -23,3 +23,4 @@ jobs:
         env:
           MODRINTH_TOKEN: ${{ secrets.MODRINTH_TOKEN }}
           COMMIT_MESSAGE: ${{ join(github.event.commits.*.message, '<br>') }}
+          IS_SNAPSHOT: true

--- a/.github/workflows/snapshots.yml
+++ b/.github/workflows/snapshots.yml
@@ -2,7 +2,7 @@ name: Dev Build
 on:
   push:
     branches:
-      - main
+      - dev
 
 jobs:
   build:
@@ -12,8 +12,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
         with:
-          distribution: 'temurin'
-          java-version: '21'
+          distribution: temurin
+          java-version: 21
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
       - name: Build
         run: ./gradlew build --stacktrace
       - name: Publish to Modrinth

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 rootProject.group = "me.h1dd3nxn1nja.chatmanager"
 
 val commitHash: String? = indraGit.commit()?.name()?.subSequence(0, 7).toString()
-val isSnapshot: Boolean = true
+val isSnapshot: Boolean = System.getenv("IS_SNAPSHOT") != null
 val content: String? = if (isSnapshot) "[$commitHash](https://github.com/Crazy-Crew/${rootProject.name}/commit/$commitHash) ${System.getenv("COMMIT_MESSAGE")}" else rootProject.file("changelog.md").readText(Charsets.UTF_8)
 
 rootProject.version = if (isSnapshot) "${libs.versions.minecraft.get()}-$commitHash" else libs.versions.chatmanager.get()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,5 @@
 plugins {
+    alias(libs.plugins.indra.git)
     alias(libs.plugins.minotaur)
 
     id("root-plugin")
@@ -6,10 +7,10 @@ plugins {
 
 rootProject.group = "me.h1dd3nxn1nja.chatmanager"
 
-val buildNumber: String? = System.getenv("BUILD_NUMBER")
-val isPublishing: String? = System.getenv("IS_PUBLISHING")
+val commitHash: String? = indraGit.commit()?.name()
+val isSnapshot: Boolean = System.getenv("IS_SNAPSHOT") != null
 
-rootProject.version = if (buildNumber != null && isPublishing == null) "${libs.versions.minecraft.get()}-$buildNumber" else libs.versions.chatmanager.get()
+rootProject.version = if (isSnapshot) "${libs.versions.minecraft.get()}-$commitHash" else libs.versions.chatmanager.get()
 rootProject.description = "The kitchen sink of Chat Management!"
 
 val mergedJar by configurations.creating<Configuration> {
@@ -39,9 +40,9 @@ modrinth {
 
     versionName = "${rootProject.version}"
     versionNumber = "${rootProject.version}"
-    versionType = "releases"
+    versionType = if (isSnapshot) "beta" else "release"
 
-    changelog = if (System.getenv("IS_SNAPSHOT") != null) System.getenv("COMMIT_MESSAGE") else rootProject.file("changelog.md").readText(Charsets.UTF_8)
+    changelog = if (isSnapshot) System.getenv("COMMIT_MESSAGE") else rootProject.file("changelog.md").readText(Charsets.UTF_8)
 
     gameVersions.addAll(listOf(libs.versions.minecraft.get()))
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,13 +35,13 @@ tasks.withType<Jar> {
 modrinth {
     token = System.getenv("MODRINTH_TOKEN")
 
-    projectId = rootProject.name
+    projectId = "SimpleEdit"
 
     versionName = "${rootProject.version}"
     versionNumber = "${rootProject.version}"
     versionType = "releases"
 
-    changelog = rootProject.file("changelog.md").readText(Charsets.UTF_8)
+    changelog = if (System.getenv("IS_SNAPSHOT") != null) System.getenv("COMMIT_MESSAGE") else rootProject.file("changelog.md").readText(Charsets.UTF_8)
 
     gameVersions.addAll(listOf(libs.versions.minecraft.get()))
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,9 +8,9 @@ plugins {
 rootProject.group = "me.h1dd3nxn1nja.chatmanager"
 
 val commitHash: String? = indraGit.commit()?.name()
-val isSnapshot: Boolean = System.getenv("IS_SNAPSHOT") != null
+val isSnapshot: Boolean = true
 
-rootProject.version = if (isSnapshot) "${libs.versions.minecraft.get()}-$commitHash" else libs.versions.chatmanager.get()
+rootProject.version = if (isSnapshot) "${libs.versions.minecraft.get()}-${commitHash?.subSequence(0, 7)}" else libs.versions.chatmanager.get()
 rootProject.description = "The kitchen sink of Chat Management!"
 
 val mergedJar by configurations.creating<Configuration> {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,10 +7,11 @@ plugins {
 
 rootProject.group = "me.h1dd3nxn1nja.chatmanager"
 
-val commitHash: String? = indraGit.commit()?.name()
+val commitHash: String? = indraGit.commit()?.name()?.subSequence(0, 7).toString()
 val isSnapshot: Boolean = true
+val content: String? = if (isSnapshot) "[$commitHash](https://github.com/Crazy-Crew/${rootProject.name}/commit/$commitHash) ${System.getenv("COMMIT_MESSAGE")}" else rootProject.file("changelog.md").readText(Charsets.UTF_8)
 
-rootProject.version = if (isSnapshot) "${libs.versions.minecraft.get()}-${commitHash?.subSequence(0, 7)}" else libs.versions.chatmanager.get()
+rootProject.version = if (isSnapshot) "${libs.versions.minecraft.get()}-$commitHash" else libs.versions.chatmanager.get()
 rootProject.description = "The kitchen sink of Chat Management!"
 
 val mergedJar by configurations.creating<Configuration> {
@@ -42,7 +43,7 @@ modrinth {
     versionNumber = "${rootProject.version}"
     versionType = if (isSnapshot) "beta" else "release"
 
-    changelog = if (isSnapshot) System.getenv("COMMIT_MESSAGE") else rootProject.file("changelog.md").readText(Charsets.UTF_8)
+    changelog = content
 
     gameVersions.addAll(listOf(libs.versions.minecraft.get()))
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,7 +37,7 @@ tasks.withType<Jar> {
 modrinth {
     token = System.getenv("MODRINTH_TOKEN")
 
-    projectId = "SimpleEdit"
+    projectId = rootProject.name
 
     versionName = "${rootProject.version}"
     versionNumber = "${rootProject.version}"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,6 +2,7 @@
 hangar = { id = "io.papermc.hangar-publish-plugin", version.ref = "hangar" }
 runPaper = { id = "xyz.jpenilla.run-paper", version.ref = "runPaper" }
 minotaur = { id = "com.modrinth.minotaur", version.ref = "minotaur" }
+indra-git = { id = "net.kyori.indra.git", version.ref = "indra-git" }
 shadow = { id = "com.gradleup.shadow", version.ref = "shadow" }
 
 [libraries]
@@ -31,8 +32,9 @@ minecraft = "1.21.5"
 
 # Gradle Plugins
 shadow = "9.0.0-beta12"
+indra-git = "3.1.3"    # https://github.com/KyoriPowered/indra
 runPaper = "2.3.1"
-minotaur = "2.8.7"
+minotaur = "2.8.7" # https://github.com/modrinth/minotaur
 hangar = "0.1.2"
 
 # Placeholder API


### PR DESCRIPTION
### Description
This changes the initial build system, and moves all publishing to Modrinth.

- Every single commit triggers the github action to send a build to modrinth labeled "Beta" with the commit id and commit message
  - With each commit, an embed message containing the changelog and current version will be sent to discord without a role ping. The discord embed will include a link to the modrinth build.
![image](https://github.com/user-attachments/assets/2d8dfd5c-71be-4d57-8644-1993178012be)

- If I add a tag to a commit, the release workflow will trigger sending a versioned build that is considered "stable"
  - This build will publish to modrinth using semver i.e. 4.0.3 and will send an embed message to discord with a role ping with similar information previously.
- A github release will be created as well.
