### PR TITLE
Update ChatCooldowns to handle nulls

### DIFF
--- a/paper/src/main/java/com/ryderbelserion/chatmanager/api/cooldowns/ChatCooldowns.java
+++ b/paper/src/main/java/com/ryderbelserion/chatmanager/api/cooldowns/ChatCooldowns.java
@@ -22,7 +22,7 @@ public class ChatCooldowns {
     }
 
     public int getTime(UUID uuid) {
-        return map.get(uuid);
+        return containsUser(uuid) ? map.get(uuid) : 0;
     }
 
     public void subtract(UUID uuid) {


### PR DESCRIPTION
On getTime method if the map does not contain the uuid return a 0 to prevent a null pointer exception